### PR TITLE
Virtual BMC 1.4.0+ support

### DIFF
--- a/roles/builder/tasks/virtualbmc.yaml
+++ b/roles/builder/tasks/virtualbmc.yaml
@@ -13,6 +13,7 @@
         mode: 0750
         owner: root
       register: vbmc_script
+      when: tripleo_version in ['pike', 'queens']
 
     - name: create systemd unit file
       template:
@@ -22,22 +23,49 @@
         mode: 0644
         owner: root
       register: install_vbmc_service
+      when: tripleo_version in ['pike', 'queens']
 
     - name: reload systemd daemon if vbmc.service changed
       command: systemctl daemon-reload
-      when: install_vbmc_service.changed
+      when:
+        - install_vbmc_service.changed
+        - tripleo_version in ['pike', 'queens']
 
     - name: register vbmc.service
       service:
         name: vbmc
         enabled: yes
         state: started
+      when: tripleo_version in ['pike', 'queens']
 
     - name: restart vbmc if script changed
       service:
         name: vbmc
         state: reloaded
-      when: vbmc_script.changed
+      when:
+        - install_vbmc_service.changed
+        - tripleo_version in ['pike', 'queens']
+
+    - name: start virtualbmc
+      service:
+        name: virtualbmc
+        enabled: yes
+        state: started
+      when: tripleo_version not in ['pike', 'queens']
+
+    - name: Create the Virtual BMCs
+      command: "vbmc add {{ item.name }} --port 112{{item.interfaces.0.mac|replace('24:42:53:21:52:','')}} --libvirt-uri qemu:///system --username ADMIN --password ADMIN" 
+      args:
+        creates: /root/.vbmc/{{ item.name }}/config
+      with_items: "{{ vms }}"
+      register: vbmc
+
+    - name: Start the Virtual BMCs (virtualbmc >= 1.4.0+)
+      command: "vbmc start {{ item.name }}"
+      with_items: "{{ vms }}"
+      when:
+        - vbmc.changed
+        - tripleo_version not in ['pike', 'queens']
 
     - name: open firewall on libvirt link
       iptables:


### PR DESCRIPTION
Starting in Rocky, we deploy VBMC 1.4 which is handled by systemd so no
need to create the scripts manually.

Closes #3