### PR TITLE
Increase the sleep to fetch vms IP

### DIFF
--- a/roles/builder/tasks/lab.yaml
+++ b/roles/builder/tasks/lab.yaml
@@ -37,7 +37,7 @@
         - gen-ssh-config
         - inventory
       shell: |
-        sleep 10 && \
+        sleep 30 && \
         virsh --connect qemu:///system domifaddr "{{item.name}}" | \
         awk '/ipv4/ {print $4}'
       register: ip_address


### PR DESCRIPTION
It can takes more than 10 seconds to start the undercloud VM and gets
the IP.

Increasing the timeout to 30s.

Closes #2