### PR TITLE
Update ctlplane-subnet with undercloud_dns

### DIFF
--- a/roles/undercloud/tasks/overcloud.yaml
+++ b/roles/undercloud/tasks/overcloud.yaml
@@ -124,3 +124,7 @@
                 openstack overcloud node import \
                   --introspect --provide \
                   ~/baremetal.json
+            - name: update the ctlplane-subnet dns server
+              shell: |
+                source ~/stackrc
+                openstack subnet set ctlplane-subnet --dns-nameserver {{ undercloud_dns }}

--- a/roles/undercloud/vars/main.yaml
+++ b/roles/undercloud/vars/main.yaml
@@ -11,3 +11,4 @@ containerized_undercloud: yes
 ci_tools: yes
 deploy_undercloud: yes
 undercloud_sample: /usr/share/python-tripleoclient/undercloud.conf.sample
+undercloud_dns: 192.168.122.1


### PR DESCRIPTION
Introduce a new parameter: undercloud_dns which default to 192.168.122.1
(IP address of the hypervisor). So overcloud nodes will be configured to
use 192.168.122.1 as DNS.