### PR TITLE
envs: update examples to have controllers with 8GB of RAM

### DIFF
--- a/environments/3ctl-1compute-swap.yaml
+++ b/environments/3ctl-1compute-swap.yaml
@@ -10,21 +10,21 @@ vms:
     autostart: yes
   - name: controller-0
     cpu: 2
-    memory: 4096
+    memory: 8192
     interfaces:
       - mac: "24:42:53:21:52:25"
       - mac: "24:42:53:21:52:26"
     autostart: no
   - name: controller-1
     cpu: 2
-    memory: 4096
+    memory: 8192
     interfaces:
       - mac: "24:42:53:21:52:35"
       - mac: "24:42:53:21:52:36"
     autostart: no
   - name: controller-2
     cpu: 2
-    memory: 4096
+    memory: 8192
     interfaces:
       - mac: "24:42:53:21:52:45"
       - mac: "24:42:53:21:52:46"

--- a/environments/3ctl-1compute.yaml
+++ b/environments/3ctl-1compute.yaml
@@ -9,21 +9,21 @@ vms:
     autostart: yes
   - name: controller-0
     cpu: 4
-    memory: 6144
+    memory: 8192
     interfaces:
       - mac: "24:42:53:21:52:25"
       - mac: "24:42:53:21:52:26"
     autostart: no
   - name: controller-1
     cpu: 4
-    memory: 6144
+    memory: 8192
     interfaces:
       - mac: "24:42:53:21:52:35"
       - mac: "24:42:53:21:52:36"
     autostart: no
   - name: controller-2
     cpu: 4
-    memory: 6144
+    memory: 8192
     interfaces:
       - mac: "24:42:53:21:52:45"
       - mac: "24:42:53:21:52:46"


### PR DESCRIPTION
It's a minimum to avoid timeouts.