### PR TITLE
Add undercloud_low_memory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,8 @@ semodules:
 *overcloud_image_update*
   Whether you want to get a `yum update` on the overcloud-full prior its
   upload into Glance. (Bool, default to yes)
+
+*undercloud_low_memory*
+  Creates a hieradata file to configure 1 worker per OpenStack
+  service. This hieradata file is consummed by the Undercloud.
+  (Bool, default no)

--- a/roles/undercloud/tasks/prepare.yaml
+++ b/roles/undercloud/tasks/prepare.yaml
@@ -16,6 +16,22 @@
     mode: 0640
     backup: yes
 
+- name: Enable undercloud hieradata for low memory
+  ini_file:
+    path: /home/stack/undercloud.conf
+    section: DEFAULT
+    option: hieradata_override
+    value: /home/stack/hieradata_undercloud_low_memory.yaml
+    mode: 0640
+    backup: yes
+  when: undercloud_low_memory|bool
+
+- name: Create hieradata_undercloud_low_memory.yaml
+  template:
+    dest: /home/stack/hieradata_undercloud_low_memory.yaml
+    src: hieradata_undercloud_low_memory.yaml.j2
+  when: undercloud_low_memory|bool
+
 - name: custom configuration in undercloud.conf
   ini_file:
     path: /home/stack/undercloud.conf

--- a/roles/undercloud/templates/hieradata_undercloud_low_memory.yaml.j2
+++ b/roles/undercloud/templates/hieradata_undercloud_low_memory.yaml.j2
@@ -1,0 +1,20 @@
+parameter_defaults:
+  UndercloudExtraConfig:
+    # The following are configurations for the different workers for the undercloud
+    # services.
+    undercloud_workers: 1
+    glance::api::workers: "%{hiera('undercloud_workers')}"
+    glance::registry::workers: "%{hiera('undercloud_workers')}"
+    heat::api::workers: "%{hiera('undercloud_workers')}"
+    heat::api_cfn::workers: "%{hiera('undercloud_workers')}"
+    heat::engine::num_engine_workers: "%{hiera('undercloud_workers')}"
+    ironic::api::workers: "%{hiera('undercloud_workers')}"
+    ironic::wsgi::apache::workers: "%{hiera('undercloud_workers')}"
+    keystone::wsgi::apache::workers: "%{hiera('undercloud_workers')}"
+    neutron::agents::metadata::metadata_workers: "%{hiera('undercloud_workers')}"
+    neutron::server::api_workers: "%{hiera('undercloud_workers')}"
+    nova::api::metadata_workers: "%{hiera('undercloud_workers')}"
+    nova::api::osapi_compute_workers: "%{hiera('undercloud_workers')}"
+    nova::conductor::workers: "%{hiera('undercloud_workers')}"
+    nova::scheduler::workers: "%{hiera('undercloud_workers')}"
+    swift::proxy::workers: "%{hiera('undercloud_workers')}"

--- a/roles/undercloud/vars/main.yaml
+++ b/roles/undercloud/vars/main.yaml
@@ -23,3 +23,4 @@ tmate_release: 2.2.1
 semodules: []
 overcloud_container_cli: docker
 overcloud_image_update: yes
+undercloud_low_memory: no


### PR DESCRIPTION
If undercloud_low_memory is set to 'yes', we'll create a hieradata file
that will configure OpenStack services with 1 worker on the Undercloud.

It allows to run the Undercloud in a VM with less timeouts.