### PR TITLE
Add option to override undercloud NTP server

### DIFF
--- a/roles/undercloud/tasks/prepare.yaml
+++ b/roles/undercloud/tasks/prepare.yaml
@@ -7,6 +7,15 @@
     group: stack
     mode: 0640
 
+- name: Setting NTP server in undercloud.conf
+  ini_file:
+    path: /home/stack/undercloud.conf
+    section: DEFAULT
+    option: undercloud_ntp_servers
+    value: "{{ undercloud_ntp_server }}"
+    mode: 0640
+    backup: yes
+
 - name: Enable masquerading in undercloud.conf
   ini_file:
     path: /home/stack/undercloud.conf

--- a/roles/undercloud/vars/main.yaml
+++ b/roles/undercloud/vars/main.yaml
@@ -25,3 +25,4 @@ overcloud_container_cli: docker
 overcloud_image_update: yes
 undercloud_low_memory: no
 disable_selinux: no
+undercloud_ntp_server: pool.ntp.org


### PR DESCRIPTION
This is useful in environments where the libvirt host doesn't have access to pool.ntp.org.