### PR TITLE
Use overcloud_image_update in more tasks

### DIFF
--- a/roles/undercloud/tasks/overcloud.yaml
+++ b/roles/undercloud/tasks/overcloud.yaml
@@ -76,11 +76,13 @@
       become_user: stack
       block:
         - name: copy overcloud firstboot script
+          when: overcloud_image_update|bool
           template:
             dest: /tmp/overcloud-firstboot
             src: overcloud-firstboot.j2
             mode: 0755
         - name: modify overcloud image
+          when: overcloud_image_update|bool
           shell: |
             virt-sysprep -a /home/stack/overcloud_imgs/overcloud-full.qcow2 \
               --copy-in /etc/yum.conf:/etc/ \


### PR DESCRIPTION
Do not run the virt commands if overcloud_image_update is set to false,
we expect the operator to not wanting any update in the images.