### PR TITLE
Fix typo with local images YAML

### DIFF
--- a/roles/undercloud/tasks/prepare.yaml
+++ b/roles/undercloud/tasks/prepare.yaml
@@ -86,12 +86,12 @@
       template:
         dest: /home/stack/overcloud-yml/container-cli.yaml
         src: container-cli.yaml.j2
-    - name: push local_image.yaml setting
+    - name: push local_images.yaml setting
       tags:
         - baremetal
       template:
-        dest: /home/stack/local_image.yaml
-        src: local_image.yaml
+        dest: /home/stack/local_images.yaml
+        src: local_images.yaml
     - name: push basic deploy script
       tags:
         - baremetal


### PR DESCRIPTION
The file is named local_iamges in roles/undercloud/templates/overcloud-deploy.sh.j2
so let's update the ansible tasks.