### PR TITLE
overcloud: disable iscsid.socker right after installing libguestfs-tools

### DIFF
--- a/roles/undercloud/tasks/overcloud.yaml
+++ b/roles/undercloud/tasks/overcloud.yaml
@@ -3,6 +3,19 @@
     name: libguestfs-tools
     state: present
 
+# iscsi is a dependency of libguestfs-tools
+# but can conflict with the iscsi container on the undercloud
+- name: stat /lib/systemd/system/iscsid.socket
+  stat:
+    path: /lib/systemd/system/iscsid.socket
+  register: stat_iscsid_socket
+- name: Stop and disable iscsid.socket service
+  service:
+    name: iscsid.socket
+    state: stopped
+    enabled: no
+  when: stat_iscsid_socket.stat.exists
+
 - name: image management on non-RHEL system
   tags:
     - baremetal


### PR DESCRIPTION
libguestfs-tools pulls as a dependency iscsid rpms, and enable by
default the iscsi.socket. So if you reboot the undercloud, the
iscsi.socket will be enabled and running on the host which conflicts
with the iscsi container deployed on the undercloud, used by Nova and
Ironic. This patch will make sure we disable the socket on the host.