### PR TITLE
Add possibility to host 'virtuser' home elsewhere than '/home'

### DIFF
--- a/roles/builder/templates/scripts/lab-destroy.j2
+++ b/roles/builder/templates/scripts/lab-destroy.j2
@@ -3,25 +3,25 @@
 source /usr/local/bin/lab-helpers
 
 do_destroy() {
-  for i in $($VIRSH list --all --name | grep {{vm_prefix}}); do
-    $VIRSH destroy $i;
-    $VIRSH undefine $i;
-    rm -f /home/{{virt_user}}/workload/${i}*
-  done
-  sudo systemctl stop virtualbmc
-  sleep 10 #ensure vbmc is down
-  sudo killall vbmc # kill last things if needed
-  sudo rm -rf /root/.vbmc
-  sudo rm -rf /home/{{virt_user}}/.vbmc
+    for i in $($VIRSH list --all --name | grep {{vm_prefix}}); do
+        $VIRSH destroy $i;
+        $VIRSH undefine $i;
+        rm -f {{ base_home_dir }}{{ virt_user }}/workload/${i}*
+    done
+    sudo systemctl stop virtualbmc
+    sleep 10 #ensure vbmc is down
+    sudo killall vbmc # kill last things if needed
+    sudo rm -rf /root/.vbmc
+    sudo rm -rf {{ base_home_dir }}{{virt_user}}/.vbmc
 }
 
-echo -n 'Destroy the lab? [Ny] ' 
+echo -n 'Destroy the lab? [Ny] '
 read -r destroy
 case $destroy in
-  y|Y)
-    do_destroy
-    ;;
-  *)
-    echo 'Aborting on user request'
-    ;;
+    y|Y)
+        do_destroy
+        ;;
+    *)
+        echo 'Aborting on user request'
+        ;;
 esac

--- a/roles/builder/vars/main.yaml
+++ b/roles/builder/vars/main.yaml
@@ -66,7 +66,8 @@ vms:
     autostart: no
 
 virt_user: virtuser
-basedir: "/home/{{virt_user}}"
+base_home_dir: "/home"
+basedir: "{{ base_home_dir }}/{{virt_user}}"
 undercloud_password: fooBar
 centos_mirror: no
 manage_mirror_device: yes


### PR DESCRIPTION
For disk availability, tripleo-lab should allow to host this user
wherever the operator wants.

This patch fixes as well the wrong bash indentation for lab-destroy
script.

Signed-off-by: Gael Chamoulaud <gchamoul@redhat.com>