### PR TITLE
Define ironic root_device by size

### DIFF
--- a/roles/undercloud/templates/baremetal.json.j2
+++ b/roles/undercloud/templates/baremetal.json.j2
@@ -10,7 +10,7 @@
       "memory": "{{node.memory}}",
       "disk": "{{node.disksize | default('100')}}",
 {% if node.name is match('^ceph') %}
-      "root_device": {"name": "sda,hda,vda"},
+      "root_device": {"size": "{{node.disksize | default('100')}}"},
 {% endif %}
 {% if tripleo_version not in ['rocky', 'master'] %}
       "mac": ["{{node.interfaces[0].mac}}"],


### PR DESCRIPTION
The root_device defaults to name: "sda,hda,vda" which does not seem
correct. The documentation [1] indicates this should be the (exact)
device name, e.g /dev/md0, and defines how to use operators if
collections should be used. The use of name is also not recommended
in the same documentation as it can vary.

Because the OSD(s) are 50G and the root disk is 100G we can define
the root_device by size.

[1] https://docs.openstack.org/ironic/pike/install/include/root-device-hints.html