### PR TITLE
Delete overcloud with mistral workflow not just heat stack

### DIFF
--- a/roles/undercloud/templates/overcloud-deploy.sh.j2
+++ b/roles/undercloud/templates/overcloud-deploy.sh.j2
@@ -23,5 +23,5 @@ stdbuf -i0 -o0 -e0 openstack overcloud deploy \
 ret_val=$?
 
 if [ $ret_val -ne 0 ] && [ -n $1 ] && [ "$1" = '--delete-if-fail' ]; then
-  openstack stack delete --yes --wait overcloud
+  openstack overcloud delete overcloud --yes
 fi


### PR DESCRIPTION
Running "openstack stack delete" will delete most of the overcloud
but the deployment plan will remain in Swift. It is better to use
"openstack overcloud delete" which triggers a mistral workflow which
will delete the heat stack and also clean up the deployment plan.