### PR TITLE
Do not nest CephPoolDefaultSize and CephPoolDefaultPgNum

### DIFF
--- a/roles/undercloud/templates/ceph-params.yaml.j2
+++ b/roles/undercloud/templates/ceph-params.yaml.j2
@@ -1,8 +1,7 @@
 ---
 parameter_defaults:
-  CephConfigOverrides:
-    CephPoolDefaultSize: {{ vms|map(attribute='name')|select("match", '^ceph.+')|list|length }}
-    CephPoolDefaultPgNum: 256
+  CephPoolDefaultSize: {{ vms|map(attribute='name')|select("match", '^ceph.+')|list|length }}
+  CephPoolDefaultPgNum: 256
   CephAnsibleDisksConfig:
     devices:
       - /dev/sdb


### PR DESCRIPTION
CephConfigOverrides passes its content directly to the ceph.conf global
section. CephPoolDefaultSize and CephPoolDefaultPgNum should not be
nested inside of CephConfigOverrides but used on their own.