### PR TITLE
Add option to deploy Ironic with disk cleaning enabled

### DIFF
--- a/environments/disk-cleaning.yaml
+++ b/environments/disk-cleaning.yaml
@@ -1,0 +1,4 @@
+undercloud_config:
+  - section: DEFAULT
+    option: clean_nodes
+    value: true


### PR DESCRIPTION
The undercloud will be deployed with Ironic's node cleaning
feature enabled if the new @environments/disk-cleaning.yaml
is passed.

Ceph expects clean disks with each new deployment so this
feature is useful for Ceph re-redeployment on the same nodes.

Fixes: #41