### PR TITLE
Apply overrides from environment-directory last during deploy

### DIFF
--- a/environments/disk-cleaning.yaml
+++ b/environments/disk-cleaning.yaml
@@ -1,0 +1,4 @@
+undercloud_config:
+  - section: DEFAULT
+    option: clean_nodes
+    value: true

--- a/roles/undercloud/tasks/config.yaml
+++ b/roles/undercloud/tasks/config.yaml
@@ -106,13 +106,7 @@
       package:
         name: "https://trunk.rdoproject.org/centos7/current/{{tripleo_repo_version.stdout}}"
         state: present
-    - name: enable tripleo_version repository
-      when: not standalone_ceph|bool
-      command: tripleo-repos -b "{{tripleo_version}}" current-tripleo
-      args:
-        creates: "/etc/yum.repos.d/delorean-{{tripleo_version}}.repo"
     - name: enable tripleo_version repository with ceph
-      when: standalone_ceph|bool
       command: tripleo-repos -b "{{tripleo_version}}" current-tripleo ceph
       args:
         creates: "/etc/yum.repos.d/delorean-{{tripleo_version}}.repo"

--- a/roles/undercloud/tasks/packages.yaml
+++ b/roles/undercloud/tasks/packages.yaml
@@ -19,7 +19,6 @@
     state: present
 
 - name: install requested packages for ceph
-  when: standalone_ceph|bool
   package:
     name: [ceph-ansible, util-linux]
     state: installed

--- a/roles/undercloud/templates/ceph-params.yaml.j2
+++ b/roles/undercloud/templates/ceph-params.yaml.j2
@@ -1,7 +1,7 @@
 ---
 parameter_defaults:
   CephPoolDefaultSize: {{ vms|map(attribute='name')|select("match", '^ceph.+')|list|length }}
-  CephPoolDefaultPgNum: 256
+  CephPoolDefaultPgNum: 32
   CephAnsibleDisksConfig:
     devices:
       - /dev/sdb

--- a/roles/undercloud/templates/overcloud-deploy.sh.j2
+++ b/roles/undercloud/templates/overcloud-deploy.sh.j2
@@ -11,6 +11,9 @@ stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   -e /usr/share/openstack-tripleo-heat-templates/environments/disable-telemetry.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/enable-swap.yaml \
+  {% if vms|map(attribute='name')|select("match", '^ceph')|list|length > 0 -%}
+  -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml \
+  {% endif -%}
   {% if vms|map(attribute='name')|select("match", '^controller.+')|list|length > 1-%}
   -e /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml \
   {% else -%}

--- a/roles/undercloud/templates/overcloud-deploy.sh.j2
+++ b/roles/undercloud/templates/overcloud-deploy.sh.j2
@@ -7,7 +7,6 @@ stdbuf -i0 -o0 -e0 openstack tripleo container image prepare \
 
 stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   --templates /usr/share/openstack-tripleo-heat-templates/ \
-  --environment-directory ~/overcloud-yml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/disable-telemetry.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/enable-swap.yaml \
@@ -22,6 +21,7 @@ stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   {% for env in additional_envs %}
   -e {{ env }} \
   {% endfor %}
+  --environment-directory ~/overcloud-yml \
   --ntp-server pool.ntp.org --libvirt-type qemu 2>&1 | tee -a ~/install-overcloud.log
 ret_val=$?
 

--- a/roles/undercloud/templates/overcloud-deploy.sh.j2
+++ b/roles/undercloud/templates/overcloud-deploy.sh.j2
@@ -22,7 +22,7 @@ stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   {% for env in additional_envs %}
   -e {{ env }} \
   {% endfor %}
-  --ntp-server pool.ntp.org --libvirt-type qemu 2>&1 | tee -a ~/deploy-overcloud.log
+  --ntp-server pool.ntp.org --libvirt-type qemu 2>&1 | tee -a ~/install-overcloud.log
 ret_val=$?
 
 if [ $ret_val -ne 0 ] && [ -n $1 ] && [ "$1" = '--delete-if-fail' ]; then


### PR DESCRIPTION
Convention is to use --environment-directory to refer to a
directory of environment variables which override the defaults
found in /usr/share/openstack-tripleo-heat-templates/environments.
Because each environment file is evaluated in order, this directory
of overrides should be referenced after the references to the
defaults found in /usr/share.

Fixes: #44