### PR TITLE
Set PgNum default based on defaults

### DIFF
--- a/roles/undercloud/templates/ceph-params.yaml.j2
+++ b/roles/undercloud/templates/ceph-params.yaml.j2
@@ -1,7 +1,7 @@
 ---
 parameter_defaults:
   CephPoolDefaultSize: {{ vms|map(attribute='name')|select("match", '^ceph.+')|list|length }}
-  CephPoolDefaultPgNum: 256
+  CephPoolDefaultPgNum: 32
   CephAnsibleDisksConfig:
     devices:
       - /dev/sdb


### PR DESCRIPTION
By default there are three Ceph nodes with one OSD
each so the default PgNum should be 32. This value
produces HEALTH_OK and creates the four default pools.
The current value of 256 will fail the deployment as
as Ceph's overdose protection will refuse to create
the OpenStack pools but you may not notice because
of issue #44. The same happens with PGNum 64.

Fixes: #38