### PR TITLE
Apply overrides from environment-directory last during deploy

### DIFF
--- a/roles/undercloud/templates/overcloud-deploy.sh.j2
+++ b/roles/undercloud/templates/overcloud-deploy.sh.j2
@@ -7,7 +7,6 @@ stdbuf -i0 -o0 -e0 openstack tripleo container image prepare \
 
 stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   --templates /usr/share/openstack-tripleo-heat-templates/ \
-  --environment-directory ~/overcloud-yml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/disable-telemetry.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/enable-swap.yaml \
@@ -22,6 +21,7 @@ stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   {% for env in additional_envs %}
   -e {{ env }} \
   {% endfor %}
+  --environment-directory ~/overcloud-yml \
   --ntp-server pool.ntp.org --libvirt-type qemu 2>&1 | tee -a ~/install-overcloud.log
 ret_val=$?
 


### PR DESCRIPTION
Convention is to use --environment-directory to refer to a
directory of environment variables which override the defaults
found in /usr/share/openstack-tripleo-heat-templates/environments.
Because each environment file is evaluated in order, this directory
of overrides should be referenced after the references to the
defaults found in /usr/share.

Fixes: #44