### PR TITLE
Support num_osds per ceph node

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,6 @@ modify_container:
     ref: refs/changes/60/661760/7
     container: neutron-server
 ```
+
+*num_osds*
+  The number of OSD disks created per ceph node (int, default 1)

--- a/roles/builder/tasks/libvirt.yaml
+++ b/roles/builder/tasks/libvirt.yaml
@@ -207,18 +207,19 @@
       loop_control:
         label: "{{ item.0.name }}"
 
-    - name: create OSD for ceph instances if any
+    - name: create OSD(s) for ceph instances if any
       tags:
         - images
       when:
-        - item.0.name is match('^ceph-.*')
-      command: "qemu-img create -f raw {{ vm_prefix }}-oc{{ item.1 }}-{{ item.0.name }}-osd.img 50G"
+        - item.0.0.name is match('^ceph-.*')
+      command: "qemu-img create -f raw {{ vm_prefix }}-oc{{ item.0.1 }}-{{ item.0.0.name }}-osd-{{ disk_index % num_osds}}.img 50G"
       args:
-        creates:  "{{ basedir }}/workload/{{ vm_prefix }}-oc{{ item.1 }}-{{ item.0.name }}-osd.img"
+        creates:  "{{ basedir }}/workload/{{ vm_prefix }}-oc{{ item.0.1 }}-{{ item.0.0.name }}-osd-{{ disk_index % num_osds}}.img"
         chdir: "{{ basedir }}/workload"
-      loop: "{{ vms|product(overclouds_range)|list }}"
+      loop: "{{ vms|product(overclouds_range)|product(range(0, num_osds)|list)|list }}"
       loop_control:
-        label: "{{ item.0.name }}"
+        label: "{{ item.0.0.name }}-osd-{{ disk_index % num_osds}}"
+        index_var: disk_index
 
     - name: push proxy config if needed
       template:

--- a/roles/builder/templates/domain.xml.j2
+++ b/roles/builder/templates/domain.xml.j2
@@ -30,11 +30,15 @@
     </disk>
     {% endif %}
     {% if item.0.name is match('^ceph-.*') %}
+    {# exclude 'a' and 'b' from letters as they're taken by root and swap #}
+    {% set letters='cdefghijklmnopqrstuvwxyz' %}
+    {% for osd in range(0, num_osds) %}
     <disk type='file' device='disk'>
       <driver name='qemu' type='raw'/>
-      <source file='{{basedir}}/workload/{{vm_prefix}}-oc{{item.1}}-{{item.0.name}}-osd.img'/>
-      <target dev='hdb'/>
+      <source file='{{basedir}}/workload/{{vm_prefix}}-oc{{item.1}}-{{item.0.name}}-osd-{{osd}}.img'/>
+      <target dev='sd{{letters[osd]}}'/>
     </disk>
+    {% endfor %}
     {% endif %}
     {% for interface in item.0.interfaces %}
     <interface type='network'>

--- a/roles/builder/vars/main.yaml
+++ b/roles/builder/vars/main.yaml
@@ -80,3 +80,4 @@ growfs_part: /dev/sda1
 guestfs_appliance: "appliance-1.38.0.tar.xz"
 python_interpreter: /usr/bin/python
 undercloud_hostname: undercloud.localdomain
+num_osds: 1


### PR DESCRIPTION
The new parameter num_osds defaults to 1. The builder role
uses it to create that number of OSD disks per node. Naming
of OSD disks found in workload directory has been extended
to include "-i" for i in num_osds. The domain template now
loops num_osds times to define additional disks.

This is useful better simulating Ceph deployments since most
people deploy >1 one OSD per node.