### PR TITLE
Restrict some tasks on CentOS

### DIFF
--- a/roles/builder/tasks/libvirt.yaml
+++ b/roles/builder/tasks/libvirt.yaml
@@ -132,11 +132,15 @@
         - configs
 
     - name: centos-7
-      when: os_version == 7
+      when:
+        - base_image == 'centos'
+        - os_version == 7
       import_tasks: centos-7.yaml
 
     - name: centos-8
-      when: os_version == 8
+      when:
+        - base_image == 'centos'
+        - os_version == 8
       import_tasks: centos-8.yaml
 
     - name: are we re-deploying upon existing deploy

--- a/roles/undercloud/tasks/packages.yaml
+++ b/roles/undercloud/tasks/packages.yaml
@@ -25,6 +25,7 @@
 
 - name: Install network-scripts-openvswitch
   when:
+    - base_image == 'centos'
     - os_version == 8
   package:
     name: network-scripts-openvswitch


### PR DESCRIPTION
Some tasks were running depending on os_version but this is not enough,
some of they would fail or are not needed on RHEL.