### PR TITLE
Add ceph dashboard service support

### DIFF
--- a/environments/standalone-ceph.yaml
+++ b/environments/standalone-ceph.yaml
@@ -1,2 +1,3 @@
 ---
 standalone_ceph: true
+ceph_dashboard: false

--- a/roles/standalone/templates/deploy.sh.j2
+++ b/roles/standalone/templates/deploy.sh.j2
@@ -5,6 +5,9 @@ stdbuf -i0 -o0 -e0 sudo openstack tripleo deploy \
   -e /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml \
 {% if standalone_ceph|bool %}
   -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml \
+{% if ceph_dashboard|default(False)|bool %}
+  -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-dashboard.yaml \
+{% endif -%}
 {% endif %}
 {% if standalone_ceph|bool %}
   -e /home/stack/ceph_parameters.yaml \

--- a/roles/undercloud/templates/overcloud-deploy.sh.j2
+++ b/roles/undercloud/templates/overcloud-deploy.sh.j2
@@ -18,6 +18,9 @@ stdbuf -i0 -o0 -e0 openstack overcloud deploy \
   -e /usr/share/openstack-tripleo-heat-templates/environments/enable-swap.yaml \
   {% if vms|map(attribute='name')|select("match", '^ceph')|list|length > 0 -%}
   -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml \
+  {% if ceph_dashboard|default(False)|bool %}
+  -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-dashboard.yaml \
+  {% endif -%}
   {% endif -%}
   {% if base_image == 'centos' and vms|map(attribute='name')|select("match", '^controller.+')|list|length > 1 -%}
   -e /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml \


### PR DESCRIPTION
This patch adds a condition to check if the boolean
that trigger the ceph dashboard deployment is true.
if it's added to the environement and set on true,
the proper template is added to the overcloud-deploy
script.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>