### PR TITLE
Replace unarchive with get_url

### DIFF
--- a/roles/builder/tasks/libguestfs.yaml
+++ b/roles/builder/tasks/libguestfs.yaml
@@ -1,10 +1,19 @@
 ---
-- name: fetch and uncompress libguestfs appliance
+- name: fetch libguestfs appliance
   tags:
     - builder-bootstrap
+  get_url:
+    dest: "{{ basedir }}/images/appliance-{{ guestfs_appliance_version }}.tar.xz"
+    checksum: "{{ guestfs_appliance_checksum }}"
+    url: http://download.libguestfs.org/binaries/appliance/appliance-{{ guestfs_appliance_version }}.tar.xz
+  register: appliance_archive
+
+- name: uncompress libguestfs appliance
+  tags:
+    - builder-bootstrap
+  when: appliance_archive is changed
   unarchive:
-    creates: /usr/local/src/appliance
-    src: "http://download.libguestfs.org/binaries/appliance/{{ guestfs_appliance }}"
+    src: "{{ appliance_archive.dest }}"
     dest: "/usr/local/src/"
     remote_src: true
 

--- a/roles/builder/tasks/main.yaml
+++ b/roles/builder/tasks/main.yaml
@@ -1,7 +1,7 @@
 - import_tasks: packages.yaml
+- import_tasks: libvirt.yaml
 - import_tasks: libguestfs.yaml
 - import_tasks: services.yaml
-- import_tasks: libvirt.yaml
 - import_tasks: scripts.yaml
 - import_tasks: undercloud.yaml
 - import_tasks: lab.yaml

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -27,7 +27,8 @@ dlrn_baseurl: >-
 domain: mydomain.tld
 freeipa_admin_password: change-me-password
 freeipa_directory_password: ChangeMePassword
-guestfs_appliance: "appliance-1.38.0.tar.xz"
+guestfs_appliance_version: "1.40.1"
+guestfs_appliance_checksum: 'sha1:525522aaf4fcc4f5212cc2a9e98ee873d125536e'
 growfs_part: /dev/sda1
 local_registry: 'true'
 oc_image_rpms: []


### PR DESCRIPTION
unarchive src: :// is very simple [1]. If something is already in dst it
won't redownload and reunpack. The same is for bumping version in env
variable. This patch replaces to more robust way recommended in [1] in
src section. Also this patch bumps version of appliance to 1.40.0

[1] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/unarchive_module.html