### PR TITLE
Move dnf.conf task to main

### DIFF
--- a/roles/undercloud_prepare/tasks/main.yaml
+++ b/roles/undercloud_prepare/tasks/main.yaml
@@ -17,6 +17,12 @@
     overclouds_range: "{{ range(0, overclouds | default(1) | int) | list }}"
 
 - import_tasks: swap.yaml
+
+- name: check dnf presence
+  stat:
+    path: /etc/dnf/dnf.conf
+  register: dnf_state
+
 - name: Set up proxy if needed
   tags:
     - lab

--- a/roles/undercloud_prepare/tasks/proxy.yaml
+++ b/roles/undercloud_prepare/tasks/proxy.yaml
@@ -1,9 +1,4 @@
 ---
-- name: check dnf presence
-  stat:
-    path: /etc/dnf/dnf.conf
-  register: dnf_state
-
 - name: set proxy for yum
   ini_file:
     backup: true


### PR DESCRIPTION
Now it's part of proxy.yaml and if proxy is not set, the task is
not executed and dnf_state.stat.exists is not defined, which break
tasks in config.yaml.