### PR TITLE
Use condition for centos8 tasks

### DIFF
--- a/environments/no-stream.yaml
+++ b/environments/no-stream.yaml
@@ -1,0 +1,3 @@
+---
+centos_variant: ""
+tripleo_repos_stream: false

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -10,7 +10,8 @@ ansible_tripleo_podman_name: >-
   {%- else %}tripleo-podman {% endif -%}
 basedir: "/home/{{virt_user}}"
 base_image: centos
-centos_variant: ""
+centos_variant: "stream"
+tripleo_repos_stream: true
 container_prepare_overrides: {}
 containerized_undercloud: true
 custom_ca: ''
@@ -33,7 +34,7 @@ guestfs_appliance_checksum: "sha1:525522aaf4fcc4f5212cc2a9e98ee873d125536e"
 growfs_part: /dev/sda1
 local_registry: 'true'
 oc_image_rpms: []
-os_version: 7
+os_version: 8
 overcloud_container_cli: podman
 overcloud_image_update: true
 overcloud_images:


### PR DESCRIPTION
When running w/o additional settings, centos version by default is
7 and when centos8 tasks play unconditionally, the playbook breaks.
Also set default centos version to 8.