### PR TITLE
Include dnf task everywhere it's used

### DIFF
--- a/roles/undercloud_prepare/tasks/config.yaml
+++ b/roles/undercloud_prepare/tasks/config.yaml
@@ -1,4 +1,9 @@
 ---
+- name: check dnf presence
+  stat:
+    path: /etc/dnf/dnf.conf
+  register: dnf_state
+
 - name: ensure sshd does not rely on gssapi
   tags:
     - lab

--- a/roles/undercloud_prepare/tasks/main.yaml
+++ b/roles/undercloud_prepare/tasks/main.yaml
@@ -17,12 +17,6 @@
     overclouds_range: "{{ range(0, overclouds | default(1) | int) | list }}"
 
 - import_tasks: swap.yaml
-
-- name: check dnf presence
-  stat:
-    path: /etc/dnf/dnf.conf
-  register: dnf_state
-
 - name: Set up proxy if needed
   tags:
     - lab

--- a/roles/undercloud_prepare/tasks/proxy.yaml
+++ b/roles/undercloud_prepare/tasks/proxy.yaml
@@ -1,4 +1,9 @@
 ---
+- name: check dnf presence
+  stat:
+    path: /etc/dnf/dnf.conf
+  register: dnf_state
+
 - name: set proxy for yum
   ini_file:
     backup: true


### PR DESCRIPTION
Because of import_task we need to run the task everywhere where this variable is used