### PR TITLE
Use network-data-v2 with tripleo-lab

### DIFF
--- a/roles/overcloud/tasks/deploy.yaml
+++ b/roles/overcloud/tasks/deploy.yaml
@@ -6,11 +6,6 @@
     - overcloud
   set_fact:
     oc_env_files: |-
-      {% if metalsmith | default(false) | bool %}
-      /usr/share/openstack-tripleo-heat-templates/environments/deployed-server-environment.yaml
-      /home/stack/overcloud-baremetal-deployed-{{ item }}.yaml
-      {% endif -%}
-      /usr/share/openstack-tripleo-heat-templates/environments/network-isolation.yaml
       /usr/share/openstack-tripleo-heat-templates/environments/network-environment.yaml
       /usr/share/openstack-tripleo-heat-templates/environments/disable-telemetry.yaml
       /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml
@@ -38,6 +33,11 @@
       /home/stack/containers-prepare-parameter.yaml
       /home/stack/generated-container-prepare.yaml
       /home/stack/oc{{ item }}-domain.yaml
+      {% if metalsmith | default(true) | bool %}
+      /home/stack/overcloud-baremetal-deployed-{{ item }}.yaml
+      {% endif -%}
+      /home/stack/overcloud-networks-provisioned-{{ item }}.yaml
+      /home/stack/overcloud-vips-provisioned-{{ item }}.yaml
       {% for env in additional_envs -%}
       {{ env }}
       {% endfor -%}

--- a/roles/overcloud/tasks/main.yaml
+++ b/roles/overcloud/tasks/main.yaml
@@ -4,6 +4,7 @@
 - import_tasks: scripts.yaml
 - import_tasks: manage-oc-images.yaml
 - import_tasks: upload.yaml
+- import_tasks: networks.yaml
 - import_tasks: baremetal.yaml
 
 - name: Deploy all overclouds

--- a/roles/overcloud/tasks/metalsmith.yaml
+++ b/roles/overcloud/tasks/metalsmith.yaml
@@ -22,4 +22,5 @@
     tripleo_overcloud_node_provision_output_file: "overcloud-baremetal-deployed-{{ item }}.yaml"
     tripleo_overcloud_node_provision_stack: "overcloud-{{ item }}"
     tripleo_overcloud_node_provision_deployment_file: "~/metalsmith-{{ item }}.yaml"
+    tripleo_overcloud_node_provision_network_ports: true
   loop: "{{ overclouds_range }}"

--- a/roles/overcloud/tasks/networks.yaml
+++ b/roles/overcloud/tasks/networks.yaml
@@ -1,0 +1,16 @@
+---
+- name: Provision Networks
+  shell: |
+    source ~/stackrc
+    openstack overcloud network provision \
+        /home/stack/oc{{ item }}-network-data.yaml -y \
+        --output /home/stack/overcloud-networks-provisioned-{{ item }}.yaml
+  loop: "{{ overclouds_range }}"
+- name: Provision Vips
+  shell: |
+    source ~/stackrc
+    openstack overcloud network vip provision \
+        /home/stack/vip-data-{{ item }}.yaml \
+        --stack overcloud-{{ item }} -y \
+        --output /home/stack/overcloud-vips-provisioned-{{ item }}.yaml
+  loop: "{{ overclouds_range }}"

--- a/roles/overcloud/tasks/scripts.yaml
+++ b/roles/overcloud/tasks/scripts.yaml
@@ -61,6 +61,16 @@
     src: oc-network-data.yaml.j2
   loop: "{{ overclouds_range }}"
 
+- name: push per-overcloud network data
+  tags:
+    - lab
+    - overcloud
+    - baremetal
+  template:
+    dest: "/home/stack/vip-data-{{ item }}.yaml"
+    src: vip-data.yaml.j2
+  loop: "{{ overclouds_range }}"
+
 - name: push per-overcloud network env
   tags:
     - lab

--- a/roles/overcloud/templates/metalsmith.yaml.j2
+++ b/roles/overcloud/templates/metalsmith.yaml.j2
@@ -5,7 +5,21 @@
 {% for ctl in (vms|map(attribute='name')|select("match", 'controller.+')|list) %}
     - hostname: oc{{ item }}-{{ ctl }}
       name: oc{{item}}-{{ ctl }}
-{% endfor -%}
+{% endfor %}
+  defaults:
+    networks:
+      - network: ctlplane
+        vif: true
+      - network: external_cloud_{{ item }}
+        subnet: external_cloud_{{ item }}_subnet
+      - network: internal_api_cloud_{{ item }}
+        subnet: internal_api_cloud_{{ item }}_subnet
+      - network: storage_cloud_{{ item }}
+        subnet: storage_cloud_{{ item }}_subnet
+      - network: storage_mgmt_cloud_{{ item }}
+        subnet: storage_mgmt_cloud_{{ item }}_subnet
+      - network: tenant_cloud_{{ item }}
+        subnet: tenant_cloud_{{ item }}_subnet
 
 {% if (vms|map(attribute='name')|select("match", 'compute.+')|list|length)|int > 0 %}
 - name: Compute
@@ -14,7 +28,17 @@
 {% for compute in (vms|map(attribute='name')|select("match", 'compute.+')|list) %}
     - hostname: oc{{ item }}-{{ compute }}
       name: oc{{item}}-{{ compute }}
-{% endfor -%}
+{% endfor %}
+  defaults:
+    networks:
+      - network: ctlplane
+        vif: true
+      - network: internal_api_cloud_{{ item }}
+        subnet: internal_api_cloud_{{ item }}_subnet
+      - network: storage_cloud_{{ item }}
+        subnet: storage_cloud_{{ item }}_subnet
+      - network: tenant_cloud_{{ item }}
+        subnet: tenant_cloud_{{ item }}_subnet
 {% endif -%}
 
 {% if (vms|map(attribute='name')|select("match", 'ceph.+')|list|length)|int > 0 %}
@@ -24,5 +48,13 @@
 {% for ceph in (vms|map(attribute='name')|select("match", 'ceph.+')|list) %}
     - hostname: oc{{ item }}-{{ ceph }}
       name: oc{{item}}-{{ ceph }}
-{% endfor -%}
+{% endfor %}
+  defaults:
+    networks:
+      - network: ctlplane
+        vif: true
+      - network: storage_cloud_{{ item }}
+        subnet: storage_cloud_{{ item }}_subnet
+      - network: storage_mgmt_cloud_{{ item }}
+        subnet: storage_mgmt_cloud_{{ item }}_subnet
 {% endif -%}

--- a/roles/overcloud/templates/oc-network-data.yaml.j2
+++ b/roles/overcloud/templates/oc-network-data.yaml.j2
@@ -1,61 +1,58 @@
 {% set base_ip = 1 + item|int %}
 - name: Storage
   vip: true
-  vlan: {{ base_ip }}1
   name_lower: storage_cloud_{{ item }}
   service_net_map_replace: storage
-  ip_subnet: '172.16.{{ base_ip }}1.0/24'
-  allocation_pools: [{'start': '172.16.{{ base_ip }}1.4', 'end': '172.16.{{ base_ip }}1.250'}]
-  ipv6_subnet: 'fd00:fd00:fd00:{{ base_ip }}001::/64'
-  ipv6_allocation_pools: [{'start': 'fd00:fd00:fd00:{{ base_ip }}001::10', 'end': 'fd00:fd00:fd00:{{ base_ip }}001:ffff:ffff:ffff:fffe'}]
+  subnets:
+    storage_cloud_{{ item }}_subnet:
+      ip_subnet: '172.16.{{ base_ip }}1.0/24'
+      allocation_pools: [{'start': '172.16.{{ base_ip }}1.4', 'end': '172.16.{{ base_ip }}1.250'}]
+      vlan: {{ base_ip }}1
 - name: StorageMgmt
+  vip: true
   name_lower: storage_mgmt_cloud_{{ item }}
   service_net_map_replace: storage_mgmt
-  vip: true
-  vlan: {{ base_ip }}2
-  ip_subnet: '172.16.{{ base_ip }}2.0/24'
-  allocation_pools: [{'start': '172.16.{{ base_ip }}2.4', 'end': '172.16.{{ base_ip }}2.250'}]
-  ipv6_subnet: 'fd00:fd00:fd00:{{ base_ip }}002::/64'
-  ipv6_allocation_pools: [{'start': 'fd00:fd00:fd00:{{ base_ip }}002::10', 'end': 'fd00:fd00:fd00:{{ base_ip }}002:ffff:ffff:ffff:fffe'}]
+  subnets:
+    storage_mgmt_cloud_{{ item }}_subnet:
+      ip_subnet: '172.16.{{ base_ip }}2.0/24'
+      allocation_pools: [{'start': '172.16.{{ base_ip }}2.4', 'end': '172.16.{{ base_ip }}2.250'}]
+      vlan: {{ base_ip }}2
 - name: InternalApi
+  vip: true
   name_lower: internal_api_cloud_{{ item }}
   service_net_map_replace: internal_api
-  vip: true
-  vlan: {{ base_ip }}3
-  ip_subnet: '172.16.{{ base_ip }}3.0/24'
-  allocation_pools: [{'start': '172.16.{{ base_ip }}3.4', 'end': '172.16.{{ base_ip }}3.250'}]
-  ipv6_subnet: 'fd00:fd00:fd00:{{ base_ip }}003::/64'
-  ipv6_allocation_pools: [{'start': 'fd00:fd00:fd00:{{ base_ip }}003::10', 'end': 'fd00:fd00:fd00:{{ base_ip }}003:ffff:ffff:ffff:fffe'}]
+  subnets:
+    internal_api_cloud_{{ item }}_subnet:
+      ip_subnet: '172.16.{{ base_ip }}3.0/24'
+      allocation_pools: [{'start': '172.16.{{ base_ip }}3.4', 'end': '172.16.{{ base_ip }}3.250'}]
+      vlan: {{ base_ip }}3
 - name: Tenant
   vip: false  # Tenant network does not use VIPs
   name_lower: tenant_cloud_{{ item }}
   service_net_map_replace: tenant
-  vlan: {{ base_ip }}4
-  ip_subnet: '172.16.{{ base_ip }}4.0/24'
-  allocation_pools: [{'start': '172.16.{{ base_ip }}4.4', 'end': '172.16.{{ base_ip }}4.250'}]
-  # Note that tenant tunneling is only compatible with IPv4 addressing at this time.
-  ipv6_subnet: 'fd00:fd00:fd00:{{ base_ip }}004::/64'
-  ipv6_allocation_pools: [{'start': 'fd00:fd00:fd00:{{ base_ip }}004::10', 'end': 'fd00:fd00:fd00:{{ base_ip }}004:ffff:ffff:ffff:fffe'}]
+  subnets:
+    tenant_cloud_{{ item }}_subnet:
+      ip_subnet: '172.16.{{ base_ip }}4.0/24'
+      allocation_pools: [{'start': '172.16.{{ base_ip }}4.4', 'end': '172.16.{{ base_ip }}4.250'}]
+      vlan: {{ base_ip }}4
 - name: External
   vip: true
   name_lower: external_cloud_{{ item }}
   service_net_map_replace: external
-  vlan: {{ item + 100 }}
-  ip_subnet: '192.168.{{ item + 100 }}.0/24'
-  allocation_pools: [{'start': '192.168.{{ item + 100 }}.15', 'end': '192.168.{{ item + 100 }}.100'}]
-  gateway_ip: '192.168.{{ item + 100 }}.1'
-  ipv6_subnet: '2001:db8:fd00:1{{ item + 100 }}::/64'
-  ipv6_allocation_pools: [{'start': '2001:db8:fd00:1{{ item + 100 }}::10', 'end': '2001:db8:fd00:1{{ item + 100 }}:ffff:ffff:ffff:fffe'}]
-  gateway_ipv6: '2001:db8:fd00:1{{ item + 100 }}::1'
+  subnets:
+    external_cloud_{{ item }}_subnet:
+      ip_subnet: '192.168.{{ item + 100 }}.0/24'
+      allocation_pools: [{'start': '192.168.{{ item + 100 }}.15', 'end': '192.168.{{ item + 100 }}.100'}]
+      gateway_ip: '192.168.{{ item + 100 }}.1'
+      vlan: {{ item + 100 }}
 - name: Management
   # Management network is enabled by default for backwards-compatibility, but
   # is not included in any roles by default. Add to role definitions to use.
-  enabled: true
   vip: false  # Management network does not use VIPs
   name_lower: management_cloud_{{ item }}
   service_net_map_replace: management
-  vlan: {{ base_ip }}6
-  ip_subnet: '10.0.2{{ base_ip }}.0/24'
-  allocation_pools: [{'start': '10.0.2{{ base_ip }}.4', 'end': '10.0.2{{ base_ip }}.250'}]
-  ipv6_subnet: 'fd00:fd00:fd00:{{ base_ip }}005::/64'
-  ipv6_allocation_pools: [{'start': 'fd00:fd00:fd00:{{ base_ip }}005::10', 'end': 'fd00:fd00:fd00:{{ base_ip }}005:ffff:ffff:ffff:fffe'}]
+  subnets:
+    management_cloud_{{ item }}_subnet:
+      ip_subnet: '10.0.2{{ base_ip }}.0/24'
+      allocation_pools: [{'start': '10.0.2{{ base_ip }}.4', 'end': '10.0.2{{ base_ip }}.250'}]
+      vlan: {{ base_ip }}6

--- a/roles/overcloud/templates/vip-data.yaml.j2
+++ b/roles/overcloud/templates/vip-data.yaml.j2
@@ -1,0 +1,5 @@
+- network: storage_mgmt_cloud_{{ item }}
+- network: internal_api_cloud_{{ item }}
+- network: storage_cloud_{{ item }}
+- network: external_cloud_{{ item }}
+- network: ctlplane

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -43,7 +43,7 @@ overcloud_images:
   - file: overcloud-full.tar
     content: overcloud-full.qcow2
 overclouds: 1
-metalsmith: false
+metalsmith: true
 nameservers:
   - 1.1.1.1
   - 8.8.8.8


### PR DESCRIPTION
This changes to use baremetal deployment using metalsmith and network-data-v2 by default.