### PR TITLE
Use the new tripleo-operator roles for network-v2

### DIFF
--- a/roles/overcloud/tasks/networks.yaml
+++ b/roles/overcloud/tasks/networks.yaml
@@ -1,16 +1,17 @@
 ---
 - name: Provision Networks
-  shell: |
-    source ~/stackrc
-    openstack overcloud network provision \
-        /home/stack/oc{{ item }}-network-data.yaml -y \
-        --output /home/stack/overcloud-networks-provisioned-{{ item }}.yaml
+  include_role:
+    name: tripleo.operator.tripleo_overcloud_network_provision
+  vars:
+    tripleo_overcloud_network_provision_deployment_file: "/home/stack/oc{{ item }}-network-data.yaml"
+    tripleo_overcloud_network_provision_output_file: "/home/stack/overcloud-networks-provisioned-{{ item }}.yaml"
   loop: "{{ overclouds_range }}"
+
 - name: Provision Vips
-  shell: |
-    source ~/stackrc
-    openstack overcloud network vip provision \
-        /home/stack/vip-data-{{ item }}.yaml \
-        --stack overcloud-{{ item }} -y \
-        --output /home/stack/overcloud-vips-provisioned-{{ item }}.yaml
+  include_role:
+    name: tripleo.operator.tripleo_overcloud_network_vip_provision
+  vars:
+    tripleo_overcloud_network_vip_provision_deployment_file: "/home/stack/vip-data-{{ item }}.yaml"
+    tripleo_overcloud_network_vip_provision_stack: "overcloud-{{ item }}"
+    tripleo_overcloud_network_vip_provision_output_file: "/home/stack/overcloud-vips-provisioned-{{ item }}.yaml"
   loop: "{{ overclouds_range }}"


### PR DESCRIPTION
This requires to update your tripleo-operator-ansible collection in
order to include the following 2 patches:
https://github.com/openstack/tripleo-operator-ansible/commit/526fdc05158e75b1e9b3a8ebc800ac7b115160c8
https://github.com/openstack/tripleo-operator-ansible/commit/d72f3c97ee788a4554edfbeb460d25503ee7a549

You can do this by running:
ansible-playbook config-host.yaml -e update_operator=true