### PR TITLE
Add the sneaky missing "g"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The amount of used memory for that env is about 52G, and about 20 CPU cores.
 
 ## Prerequisite
 ### Working ssh-agent on ansible-host
-A working ssh-agent must be runnin on the host launching ansible playbook. It
+A working ssh-agent must be running on the host launching ansible playbook. It
 is needed in order to hot-load the private ssh key for the undercloud access.
 
 In case you're running the playbook for a "middle machine", you can just forward


### PR DESCRIPTION
Having a missing g causes me discomfort. I could
have settled for a ' to denote that we all understand
there should have been a g, but the g has been deliberately
dropped. Maybe in an effort to show that ssh-agent is cool, and
runnin'. But without a g or a ' its all just too much for me.