### PR TITLE
Correct custom network names in domain.yaml

### DIFF
--- a/roles/overcloud/templates/domain.yaml.j2
+++ b/roles/overcloud/templates/domain.yaml.j2
@@ -1,9 +1,9 @@
 ---
 parameter_defaults:
   CloudNameExternalCloud{{item}}: overcloud{{ item }}.{{ domain }}
-  CloudNameInternalCloud{{item}}: overcloud{{ item }}.internalapicloud{{ item }}.{{ domain }}
+  CloudNameInternalApiCloud{{item}}: overcloud{{ item }}.internalapicloud{{ item }}.{{ domain }}
   CloudNameStorageCloud{{item}}: overcloud{{ item }}.storagecloud{{ item }}.{{ domain }}
-  CloudNameStorageManagementCloud{{item}}: overcloud{{ item }}.storagemgmtcloud{{ item }}.{{ domain }}
+  CloudNameStorageMgmtCloud{{item}}: overcloud{{ item }}.storagemgmtcloud{{ item }}.{{ domain }}
   CloudNameCtlplane: overcloud{{ item }}.ctlplane.{{ domain }}
   CloudDomain: {{ domain }}
   DnsSearchDomains: ["{{ domain }}"]


### PR DESCRIPTION
Looking at [1] and based on testing in oooq jobs[2], looks like
for custom networks we need to set properly set
CloudName{{network.name}}, network.name - what we define under
network-data.yaml[3]

Without these changes, internalapi and storagemgmt values are not properly
set in overcloud nodes[4]

[1] https://opendev.org/openstack/tripleo-heat-templates/src/branch/master/overcloud.j2.yaml#L57-L63
[2] https://logserver.rdoproject.org/54/31954/16/check/periodic-tripleo-ci-centos-8-ovb-3ctlr_1comp-featureset064-master/8c329a7/logs/undercloud/home/zuul/cloud-names.yaml.txt.gz
[3] https://github.com/cjeanner/tripleo-lab/blob/master/roles/overcloud/templates/oc-network-data-v2.yaml.j2#L24
[4] https://logserver.rdoproject.org/54/31954/16/check/periodic-tripleo-ci-centos-8-ovb-3ctlr_1comp-featureset064-master/383346c/logs/overcloud1-controller-0/etc/hosts.txt.gz