### PR TITLE
Fix tripleo-ansible role names condition in vars/main.yaml

### DIFF
--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,13 +1,13 @@
 ---
 additional_envs: []
 ansible_tripleo_image_serve_name: >-
-  {%- if tripleo_repos_branch == 'master' -%}
-  tripleo_image_serve
-  {%- else %}tripleo-image-serve {% endif -%}
+  {%- if tripleo_repos_branch == 'train' -%}
+  tripleo-image-serve
+  {%- else %}tripleo_image_serve {% endif -%}
 ansible_tripleo_podman_name: >-
-  {%- if tripleo_repos_branch == 'master' -%}
-  tripleo_podman
-  {%- else %}tripleo-podman {% endif -%}
+  {%- if tripleo_repos_branch == 'train' -%}
+  tripleo-podman
+  {%- else %}tripleo_podman {% endif -%}
 basedir: "/home/{{virt_user}}"
 base_image: centos
 centos_variant: "stream"


### PR DESCRIPTION
Fix ansible_tripleo_image_serve_name and ansible_tripleo_podman_name vars specified in vars/main.yaml. By looking at tripleo-ansible repo, it looks like only train branch uses dash notation in role names. All other active branches use underscore notation for role names.