### PR TITLE
Put 'excludes' under ContainerImagePrepare

### DIFF
--- a/roles/undercloud/tasks/image-prepare.yaml
+++ b/roles/undercloud/tasks/image-prepare.yaml
@@ -76,6 +76,12 @@
       set_fact:
         fcip: "{{ f_container_image_prepare['parameter_defaults']['ContainerImagePrepare'][0] }}"
 
+    - name: Include container_prepare_excludes
+      set_fact:
+        fcip: "{{ fcip |combine({'excludes': container_prepare_excludes}, recursive=True) }}"
+      when:
+        - container_prepare_excludes | length > 0
+
     - name: Update default entries
       set_fact:
         fcip: "{{ fcip |combine({'set': {item.key: item.value}}, recursive=True) }}"

--- a/roles/undercloud/templates/containers-prepare-parameter.yaml.j2
+++ b/roles/undercloud/templates/containers-prepare-parameter.yaml.j2
@@ -4,5 +4,5 @@
 {% else %}
 {% set registry_cred = {} %}
 {% endif %}
-{% set yml = {'parameter_defaults': {'ContainerImagePrepareDebug': true, 'ContainerImagePrepare': container_image, 'ContainerImageRegistryCredentials': registry_cred, 'excludes': container_prepare_excludes, 'DockerInsecureRegistryAddress': container_prepare_insecure_registries }} %}
+{% set yml = {'parameter_defaults': {'ContainerImagePrepareDebug': true, 'ContainerImagePrepare': container_image, 'ContainerImageRegistryCredentials': registry_cred, 'DockerInsecureRegistryAddress': container_prepare_insecure_registries }} %}
 {{ yml | to_nice_yaml }}


### PR DESCRIPTION
The last two lines of containers-prepare-parameter.yaml
genereated after c950d47f7db9eadc75dc61509e1439de309fcf9d
merged has "DockerInsecureRegistryAddress: []" and then
"excludes: []". However, this is not valid for "excludes"
as it is not a THT parameter. As per the tripleo-docs file
container_image_prepare.rst, the excludes list should be
in ContainerImagePrepare but not under "set" like the
tripleo-lab variable container_prepare_overrides.

This patch removes "excludes" from the jinja2 template
and updates the "fcip" tripleo-lab variable to contain
"container_prepare_excludes". This is done before "fcip"
is updated to "set" what is in the tripleo-lab variable
"container_prepare_overrides".