### PR TITLE
Fixes for CentOS 9

### DIFF
--- a/environments/vm-centos9.yaml
+++ b/environments/vm-centos9.yaml
@@ -11,16 +11,24 @@ undercloud_custom_repositories:
   - name: custom-BaseOS
     file: centos-base
     uri: http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+    gpgcheck: 1
     priority: 100
   - name: custom-appstreams
     file: centos-appstreams
     uri: http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+    gpgcheck: 1
     priority: 100
   - name: custom-crb
     file: centos-crb
     uri: http://mirror.stream.centos.org/9-stream/CRB/x86_64/os
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+    gpgcheck: 1
     priority: 100
   - name: custom-ha
     file: centos-ha
     uri: http://mirror.stream.centos.org/9-stream/HighAvailability/x86_64/os
     priority: 100
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+    gpgcheck: 1

--- a/roles/builder/tasks/packages.yaml
+++ b/roles/builder/tasks/packages.yaml
@@ -24,12 +24,12 @@
         - proxy_host is defined
     - name: install rdo-trunk deps
       get_url:
-        url: https://trunk.rdoproject.org/centos7-master/rdo-trunk-runtime-deps.repo
+        url: https://trunk.rdoproject.org/centos9-master/rdo-trunk-runtime-deps.repo
         dest: /etc/yum.repos.d/rdo-trunk-runtime-deps.repo
 
     - name: install delorean
       get_url:
-        url: https://trunk.rdoproject.org/centos7-master/puppet-passed-ci/delorean.repo
+        url: https://trunk.rdoproject.org/centos9-master/puppet-passed-ci/delorean.repo
         dest: /etc/yum.repos.d/delorean.repo
 
     - name: ensure packages are present
@@ -37,7 +37,7 @@
         use: "{{ package_use|default(omit) }}"
         name:
         - bash-completion
-        - libguestfs-tools
+        - guestfs-tools
         - libvirt
         - libvirt-client
         - libvirt-daemon

--- a/roles/builder/tasks/packages.yaml
+++ b/roles/builder/tasks/packages.yaml
@@ -35,7 +35,7 @@
         use: "{{ package_use|default(omit) }}"
         name:
         - bash-completion
-        - guestfs-tools
+        - "{{ guestfs_tools_package_name }}"
         - libvirt
         - libvirt-client
         - libvirt-daemon

--- a/roles/builder/tasks/packages.yaml
+++ b/roles/builder/tasks/packages.yaml
@@ -24,12 +24,12 @@
         - proxy_host is defined
     - name: install rdo-trunk deps
       get_url:
-        url: https://trunk.rdoproject.org/centos9-master/rdo-trunk-runtime-deps.repo
+        url: "https://trunk.rdoproject.org/{{ ansible_facts['distribution'] | lower }}{{ ansible_facts['distribution_major_version'] }}-master/rdo-trunk-runtime-deps.repo"
         dest: /etc/yum.repos.d/rdo-trunk-runtime-deps.repo
 
     - name: install delorean
       get_url:
-        url: https://trunk.rdoproject.org/centos9-master/puppet-passed-ci/delorean.repo
+        url: "https://trunk.rdoproject.org/{{ ansible_facts['distribution'] | lower }}{{ ansible_facts['distribution_major_version'] }}-master/puppet-passed-ci/delorean.repo"
         dest: /etc/yum.repos.d/delorean.repo
 
     - name: ensure packages are present

--- a/roles/builder/tasks/virtualbmc.yaml
+++ b/roles/builder/tasks/virtualbmc.yaml
@@ -50,7 +50,7 @@
 
     - name: Create the Virtual BMCs
       when: item.0.name is not match('^undercloud')
-      command: "vbmc add {{vm_prefix}}-oc{{ item.1 }}-{{ item.0.name }} --port {{ '%s-%s-oc-%s'|format(vm_prefix, item.1, item.0.name)|hashed_port }} --libvirt-uri qemu:///system --username ADMIN --password ADMIN"
+      command: "/usr/local/bin/vbmc add {{vm_prefix}}-oc{{ item.1 }}-{{ item.0.name }} --port {{ '%s-%s-oc-%s'|format(vm_prefix, item.1, item.0.name)|hashed_port }} --libvirt-uri qemu:///system --username ADMIN --password ADMIN"
       args:
         creates: "/var/lib/vbmcd/.vbmc/{{vm_prefix}}-oc{{ item.1 }}-{{ item.0.name }}/config"
       loop: "{{ vms|product(overclouds_range)|list }}"
@@ -61,7 +61,7 @@
       ignore_errors: true
 
     - name: Start the Virtual BMCs (virtualbmc >= 1.4.0+)
-      command: "vbmc start {{vm_prefix}}-oc{{ item.1 }}-{{ item.0.name }}"
+      command: "/usr/local/bin/vbmc start {{vm_prefix}}-oc{{ item.1 }}-{{ item.0.name }}"
       loop: "{{ vms|product(overclouds_range)|list }}"
       loop_control:
         label: "oc{{ item.1 }}-{{ item.0.name }}"
@@ -72,7 +72,7 @@
 
     - name: Manage iptables on older centos release
       when:
-        - ansible_facts['distribution_version'] is version('8.0', 'lt', strict=True)
+        - ansible_facts['distribution_version'] is version('8.0', 'lt')
       block:
         - name: Open port on libvirt interface for each node
           when:

--- a/roles/builder/tasks/virtualbmc.yaml
+++ b/roles/builder/tasks/virtualbmc.yaml
@@ -7,7 +7,7 @@
 
     - name: push vbmcd unit
       when:
-        - ansible_facts['python_version'] is version('3.0', 'gt', strict=False)
+        - ansible_facts['python_version'] is version('3.0', 'gt')
       copy:
         src: vbmcd.service
         dest: /etc/systemd/system/virtualbmc.service
@@ -15,7 +15,7 @@
 
     - name: create vbmcd user
       when:
-        - ansible_facts['python_version'] is version('3.0', 'gt', strict=False)
+        - ansible_facts['python_version'] is version('3.0', 'gt')
       user:
         comment: VirtualBMC Daemon user
         create_home: true
@@ -25,7 +25,7 @@
 
     - name: authorize vbmcd on libvirt
       when:
-        - ansible_facts['python_version'] is version('3.0', 'gt', strict=False)
+        - ansible_facts['python_version'] is version('3.0', 'gt')
       copy:
         dest: /etc/polkit-1/rules.d/60-vbmcd.rules
         src: vbmc-polkit.rules
@@ -92,7 +92,7 @@
 
     - name: Manage firewalld on newer centos release
       when:
-        - ansible_facts['distribution_version'] is version('8.0', 'gt', strict=False)
+        - ansible_facts['distribution_version'] is version('8.0', 'gt')
       block:
         - name: Open firewalld in libvirt zone for each node
           when:

--- a/roles/overcloud/tasks/main.yaml
+++ b/roles/overcloud/tasks/main.yaml
@@ -43,6 +43,15 @@
     dest: /etc/sysconfig/network-scripts/route-br-ctlplane
     src: undercloud-static-routes-ctlplane.j2
 
+- name: Check if routing for OC routers exists
+  command: ip ro list 10.0.{{ item }}.0/24 dev br-ctlplane
+  become: true
+  tags:
+    - lab
+    - overcloud
+  loop: "{{ overclouds_range }}"
+  register: oc_router_routing
+
 - name: Add routing for OC routers
   become: true
   tags:
@@ -50,3 +59,4 @@
     - overcloud
   command: ip ro add 10.0.{{ item }}.0/24 dev br-ctlplane
   loop: "{{ overclouds_range }}"
+  when: oc_router_routing.results.{{ item }}.stdout == ""

--- a/roles/overcloud/tasks/manage-oc-images.yaml
+++ b/roles/overcloud/tasks/manage-oc-images.yaml
@@ -101,7 +101,7 @@
       --copy-in /usr/local/src/:/usr/local/ \
       --firstboot /tmp/overcloud-firstboot \
       --update \
-      {{ (selinux_relabel_option.rc == 0) | ternary('--selinux-relabel', '') }}--enable customize \
+      {{ (selinux_relabel_option.rc == 0) | ternary('--selinux-relabel', '') }} --enable customize \
       --network \
       --truncate /etc/machine-id &> /home/stack/overcloud_imgs/overcloud-full.done
   args:

--- a/roles/standalone/tasks/deploy.yaml
+++ b/roles/standalone/tasks/deploy.yaml
@@ -27,5 +27,6 @@
     tripleo_deploy_standalone: true
     tripleo_deploy_output_dir: /home/stack
     tripleo_deploy_environment_files: "{{ standalone_env_files.split('\n') }}"
-    tripleo_deploy_local_ip: '192.168.24.2'
+    tripleo_deploy_local_ip: '192.168.24.2/24'
+    tripleo_deploy_control_virtual_ip: '192.168.24.10'
     tripleo_deploy_generate_scripts_only: "{{ not deploy_standalone | bool }}"

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -8,6 +8,10 @@ ansible_tripleo_podman_name: >-
   {%- if tripleo_repos_branch == 'train' -%}
   tripleo-podman
   {%- else %}tripleo_podman {% endif -%}
+guestfs_tools_package_name: >-
+  {%- if ansible_distribution_major_version >= 8 -%}
+  guestfs-tools
+  {%- else %}libguestfs-tools {% endif -%}
 basedir: "/home/{{virt_user}}"
 base_image: centos
 centos_variant: "stream"

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -9,7 +9,7 @@ ansible_tripleo_podman_name: >-
   tripleo-podman
   {%- else %}tripleo_podman {% endif -%}
 guestfs_tools_package_name: >-
-  {%- if ansible_distribution_major_version >= 8 -%}
+  {%- if ansible_distribution_major_version is version('8', 'ge') -%}
   guestfs-tools
   {%- else %}libguestfs-tools {% endif -%}
 basedir: "/home/{{virt_user}}"

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -72,6 +72,7 @@ tripleo_container_image_prepare_become: false
 tripleo_log_redirect: '|tee'
 tripleo_repos_branch: master
 tripleo_repos_repos:
+  - ceph
   - current-tripleo-dev
 tripleoclient_pkgname: python-tripleoclient
 tripleo_generate_scripts: true


### PR DESCRIPTION
* retrieve distribution and its versions using ansible facts
* new name of guestfs-tools package
* absolute path for vbmc
* loosened the check of distribution_version for iptables task on older releases
* implemented a check for the existence of routing on OC routers
* fixed a typo in a command line option